### PR TITLE
Feature/a02 vrcsdk version rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
@@ -28,7 +28,7 @@ namespace VitDeck.Validator
                 AddIssue(new Issue(null,
                     IssueLevel.Error,
                     "VRCSDKがインポートされていません。",
-                    "公式サイトからダウンロードして下さい。",
+                    "公式サイトからダウンロードし、インポートして下さい。",
                     solutionURL: "https://www.vrchat.net/download/sdk"
                     ));
                 return;
@@ -41,7 +41,7 @@ namespace VitDeck.Validator
                 AddIssue(new Issue(null,
                     IssueLevel.Error,
                     "VRCSDKが最新バージョンではありません。",
-                    "公式サイトからダウンロードして下さい。",
+                    "公式サイトからダウンロードし、インポートして下さい。",
                     solutionURL: "https://www.vrchat.net/download/sdk"
                     ));
             }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+namespace VitDeck.Validator
+{
+    public class A02_VRCSDKVersionRule : BaseRule
+    {
+        const string versionFilePath = "Assets/VRCSDK/version.txt";
+
+        const string sdkDownloadURL = "https://www.vrchat.net/download/sdk";
+
+        private VRCSDKVersion targetVersion;
+
+        public A02_VRCSDKVersionRule(string name, VRCSDKVersion version) : base(name)
+        {
+            targetVersion = version;
+        }
+
+        protected override void Logic(ValidationTarget target)
+        {
+
+            if (!File.Exists(versionFilePath))
+            {
+                AddIssue(new Issue(null,
+                    IssueLevel.Error,
+                    "VRCSDKがインポートされていません。",
+                    "公式サイトからダウンロードして下さい。",
+                    solutionURL: "https://www.vrchat.net/download/sdk"
+                    ));
+                return;
+            }
+
+            var currentVersion = new VRCSDKVersion(File.ReadAllText(versionFilePath));
+
+            if (currentVersion < targetVersion)
+            {
+                AddIssue(new Issue(null,
+                    IssueLevel.Error,
+                    "VRCSDKが最新バージョンではありません。",
+                    "公式サイトからダウンロードして下さい。",
+                    solutionURL: "https://www.vrchat.net/download/sdk"
+                    ));
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
@@ -10,6 +10,7 @@ namespace VitDeck.Validator
     public class A02_VRCSDKVersionRule : BaseRule
     {
         const string versionFilePath = "Assets/VRCSDK/version.txt";
+        const string versionFileGUID = "fd020b1f1669bad4199457b1a193a93a";
 
         const string sdkDownloadURL = "https://www.vrchat.net/download/sdk";
 
@@ -23,7 +24,9 @@ namespace VitDeck.Validator
         protected override void Logic(ValidationTarget target)
         {
 
-            if (!File.Exists(versionFilePath))
+            var versionFilePath = AssetDatabase.GUIDToAssetPath(versionFileGUID);
+
+            if (string.IsNullOrEmpty(versionFilePath) || !File.Exists(versionFilePath))
             {
                 AddIssue(new Issue(null,
                     IssueLevel.Error,

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs
@@ -9,7 +9,6 @@ namespace VitDeck.Validator
 {
     public class A02_VRCSDKVersionRule : BaseRule
     {
-        const string versionFilePath = "Assets/VRCSDK/version.txt";
         const string versionFileGUID = "fd020b1f1669bad4199457b1a193a93a";
 
         const string sdkDownloadURL = "https://www.vrchat.net/download/sdk";

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/A02_VRCSDKVersionRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcf7f744612cca14e91b6f4d920e8795
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/IVersion.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/IVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace VitDeck.Validator
+{
+    public interface IVersion
+    {
+        string ToInterconvertibleString();
+        string ToReadableString();
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/IVersion.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/IVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a02f7d0a5d835ac448f720fa25175f1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/InvalidVersionFormatException.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/InvalidVersionFormatException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace VitDeck.Validator
+{
+    [Serializable]
+    public class InvalidVersionFormatException : Exception
+    {
+        public InvalidVersionFormatException()
+        {
+        }
+
+        public InvalidVersionFormatException(string message) : base(message)
+        {
+        }
+
+        public InvalidVersionFormatException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InvalidVersionFormatException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/InvalidVersionFormatException.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/InvalidVersionFormatException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bfd00815bb17f7418e7f02732e581f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/VRCSDKVersion.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/VRCSDKVersion.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace VitDeck.Validator
+{
+    public class VRCSDKVersion : IVersion, IEquatable<VRCSDKVersion>, IComparable<VRCSDKVersion>
+    {
+        private readonly string rawString;
+        private readonly int Year;
+        private readonly int Month;
+        private readonly int Date;
+        private readonly int Major;
+        private readonly int Minor;
+
+        private static readonly Regex regex = new Regex(@"^(?<Year>\d+)\.(?<Month>\d+)\.(?<Date>\d+)\.(?<Major>\d+)\.(?<Minor>\d+)$");
+
+        public VRCSDKVersion(string version)
+        {
+            var match = regex.Match(version);
+            if (!match.Success)
+                throw new InvalidVersionFormatException();
+
+            rawString = version;
+
+            Year = int.Parse(match.Groups["Year"].Value);
+            Month = int.Parse(match.Groups["Month"].Value);
+            Date = int.Parse(match.Groups["Date"].Value);
+            Major = int.Parse(match.Groups["Major"].Value);
+            Minor = int.Parse(match.Groups["Minor"].Value);
+        }
+
+        public string ToInterconvertibleString()
+        {
+            return rawString;
+        }
+
+        public string ToReadableString()
+        {
+            return rawString;
+        }
+
+
+
+        public override bool Equals(object obj)
+        {
+            var version = obj as VRCSDKVersion;
+            if (version != null)
+            {
+                return Equals(version);
+            }
+            return false;
+        }
+
+        public bool Equals(VRCSDKVersion other)
+        {
+            return (object)other != null &&
+                   Year == other.Year &&
+                   Month == other.Month &&
+                   Date == other.Date &&
+                   Major == other.Major &&
+                   Minor == other.Minor;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1394553890;
+            hashCode = hashCode * -1521134295 + Year.GetHashCode();
+            hashCode = hashCode * -1521134295 + Month.GetHashCode();
+            hashCode = hashCode * -1521134295 + Date.GetHashCode();
+            hashCode = hashCode * -1521134295 + Major.GetHashCode();
+            hashCode = hashCode * -1521134295 + Minor.GetHashCode();
+            return hashCode;
+        }
+
+        public int CompareTo(VRCSDKVersion other)
+        {
+            var x = Year.CompareTo(other.Year);
+            if (x != 0) return x;
+
+            x = Month.CompareTo(other.Month);
+            if (x != 0) return x;
+
+            x = Date.CompareTo(other.Date);
+            if (x != 0) return x;
+
+            x = Major.CompareTo(other.Major);
+            if (x != 0) return x;
+
+            x = Minor.CompareTo(other.Minor);
+            return x;
+        }
+
+        public static bool operator ==(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return !lhs.Equals(rhs);
+        }
+
+        public static bool operator >(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return lhs.CompareTo(rhs) > 0;
+        }
+
+        public static bool operator <(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return lhs.CompareTo(rhs) < 0;
+        }
+
+        public static bool operator >=(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return lhs.CompareTo(rhs) >= 0;
+        }
+
+        public static bool operator <=(VRCSDKVersion lhs, VRCSDKVersion rhs)
+        {
+            return lhs.CompareTo(rhs) <= 0;
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/VRCSDKVersion.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/VRCSDKVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf5c2b78a0d45a04198949d30f082a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -27,6 +27,8 @@ namespace VitDeck.Validator
 
                 new UnityVersionRule("[A-1]Unity 2017.4.28f1で作成すること","2017.4.28f1"),
 
+                new A02_VRCSDKVersionRule("[A-2]VRCSDKは提出時点の最新バージョンを使うこと", new VRCSDKVersion("2019.09.18.12.05")),
+
             };
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/VRCSDKVersionTest.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/VRCSDKVersionTest.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+
+namespace VitDeck.Validator
+{
+    [TestFixture(TestOf = typeof(A02_VRCSDKVersionRule))]
+    public class VRCSDKVersionTest
+    {
+        [Test]
+        public void OperatorTest()
+        {
+            var version = new VRCSDKVersion("2019.09.18.12.05");
+            var sameVersion = new VRCSDKVersion("2019.09.18.12.05");
+            var prevVersion = new VRCSDKVersion("2019.09.18.12.04");
+            var nextVersion = new VRCSDKVersion("2019.09.18.12.06");
+
+            Assert.IsTrue(version > prevVersion);
+            Assert.IsFalse(version > sameVersion);
+            Assert.IsFalse(version > nextVersion);
+
+            Assert.IsFalse(version < prevVersion);
+            Assert.IsFalse(version < sameVersion);
+            Assert.IsTrue(version < nextVersion);
+
+            Assert.IsTrue(version >= prevVersion);
+            Assert.IsTrue(version >= sameVersion);
+            Assert.IsFalse(version >= nextVersion);
+
+            Assert.IsFalse(version <= prevVersion);
+            Assert.IsTrue(version <= sameVersion);
+            Assert.IsTrue(version <= nextVersion);
+
+            Assert.IsFalse(version == prevVersion);
+            Assert.IsTrue(version == sameVersion);
+            Assert.IsFalse(version == nextVersion);
+
+            Assert.IsTrue(version != prevVersion);
+            Assert.IsFalse(version != sameVersion);
+            Assert.IsTrue(version != nextVersion);
+        }
+
+        [Test]
+        public void InterconvertibleTest()
+        {
+            var version = new VRCSDKVersion("2019.09.18.12.05");
+
+            var regeneratedVersion = new VRCSDKVersion(version.ToInterconvertibleString());
+
+            Assert.AreEqual(version, regeneratedVersion);
+        }
+
+        [Test]
+        public void InvalidVersionTest()
+        {
+            Assert.Throws<InvalidVersionFormatException>(() => new VRCSDKVersion(""));
+            Assert.Throws<InvalidVersionFormatException>(() => new VRCSDKVersion("2019.09.18.12.05.01"));
+            Assert.Throws<InvalidVersionFormatException>(() => new VRCSDKVersion("2019.09.18.12"));
+            Assert.Throws<InvalidVersionFormatException>(() => new VRCSDKVersion("2019.09.18.12.abc"));
+
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/VRCSDKVersionTest.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/VRCSDKVersionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9757dc5ff3ca11a43971985765278089
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
VRCSDKのバージョンチェックルールを作成。

エラー条件は以下の通りです。
- VRCSDKがインストールされていない場合
- VRCSDKがインストールされているが、バージョンがあらかじめ指定されたものより低い場合

公式サイトから最新バージョンの情報を取得する方法も考えたのですが、ネットワーク通信(&非同期処理)が挟まってくるとトラブルシューティングがすごく大変になるので、あらかじめ設定したバージョンより新しい版を使っている場合は許可する形にしています。