### PR TITLE
Vket4RuleSetBaseにAssetPathLengthRuleを追加

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -27,6 +27,8 @@ namespace VitDeck.Validator
 
                 new UnityVersionRule("[A-1]Unity 2017.4.28f1で作成すること","2017.4.28f1"),
 
+                new AssetPathLengthRule("[B-3]ファイルパスはAsset/から数えて184文字以内に収まっていること", 184),
+
             };
         }
     }


### PR DESCRIPTION
以下のルールを追加
・[B03]ファイルパスはAssets/から数えて184文字以内に収まっていること
https://docs.google.com/spreadsheets/d/1UnLFRQsB097bPGrV76LuAo20oDi1jr5Bv02m0mXMftU/edit#gid=1837405505&range=A10