### PR TITLE
Feature/c02 static flag rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/C02_StaticFlagRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/C02_StaticFlagRule.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace VitDeck.Validator
+{
+    public class C02_StaticFlagRule : BaseRule
+    {
+
+        private const StaticEditorFlags mustFlag = StaticEditorFlags.OccludeeStatic | StaticEditorFlags.ReflectionProbeStatic;
+        private const StaticEditorFlags shouldFlag = StaticEditorFlags.BatchingStatic;
+
+        public C02_StaticFlagRule(string name) : base(name)
+        {
+        }
+
+        protected override void Logic(ValidationTarget target)
+        {
+            var rootObjects = target.GetRootObjects();
+
+            foreach(var rootObject in rootObjects)
+            {
+                var staticRoot = rootObject.transform.Find("Static");
+                if (staticRoot == null)
+                {
+                    continue;
+                }
+
+                LogicForStaticRoot(staticRoot);
+            }
+        }
+
+        private void LogicForStaticRoot(Transform staticRoot)
+        {
+            var children = staticRoot.GetComponentsInChildren<Transform>(true);
+
+            foreach(var child in children)
+            {
+                var gameObject = child.gameObject;
+                var flag = GameObjectUtility.GetStaticEditorFlags(child.gameObject);
+
+                if((flag & StaticEditorFlags.OccludeeStatic) == 0)
+                {
+                    AddIssue(new Issue(
+                        gameObject,
+                        IssueLevel.Error,
+                        "Static設定のOccludeeStaticが有効になっていません。",
+                        "必ずOccludeeStaticを有効にして下さい。"));
+                }
+
+                if ((flag & StaticEditorFlags.ReflectionProbeStatic) == 0)
+                {
+                    AddIssue(new Issue(
+                        gameObject,
+                        IssueLevel.Error,
+                        "Static設定のReflectionProbeStaticが有効になっていません。",
+                        "必ずReflectionProbeStaticを有効にして下さい。"));
+                }
+
+                if ((flag & StaticEditorFlags.BatchingStatic) == 0)
+                {
+                    AddIssue(new Issue(
+                        gameObject,
+                        IssueLevel.Warning,
+                        "Static設定のBatchingStaticが有効になっていません。",
+                        "有効にしてブースの見た目に問題が出る場合は、そのままで問題ありません。"));
+                }
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/C02_StaticFlagRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/C02_StaticFlagRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8c5d01e9f62d5d4aa8e37f9b7229035
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -31,6 +31,7 @@ namespace VitDeck.Validator
 
                 new AssetPathLengthRule("[B-3]ファイルパスはAsset/から数えて184文字以内に収まっていること", 184),
 
+                new C02_StaticFlagRule("[C-2]Staticオブジェクト以下は特定のStatic設定を行うこと"),
 
             };
         }


### PR DESCRIPTION
C-2のStaticFlagsの設定チェックを行うルールを作成。

対象
- RootObject直下にある「Static」オブジェクトとその全ての子オブジェクト(非Active含む)

警告
- BatchingStaticが有効でない

エラー
- OccludeeStaticが有効でない
- ReflectionProbeStaticが有効でない