### PR TITLE
B-4のメッシュアセット命名規則のルールを追加

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -31,6 +31,9 @@ namespace VitDeck.Validator
 
                 new AssetPathLengthRule("[B-3]ファイルパスはAsset/から数えて184文字以内に収まっていること", 184),
 
+                new AssetExtentionBlacklistRule("[B-4]メッシュアセットのファイル形式で特定のものが含まれていないこと",
+                                                new string[]{".ma", ".mb", "max", "c4d", ".blend"}
+                ),
 
             };
         }


### PR DESCRIPTION
B-4の以下のルールを追加

メッシュアセットのファイル形式が以下の拡張子と一致するか
- .ma
- .mb
- .max
- .c4d
- .blend

デフォルトで備わっているアセットの拡張子を判断するルールを使用
A04_AssetExtensionBlacklistRule