### PR TITLE
Feature/b01 booth bounds rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
@@ -73,6 +73,9 @@ namespace VitDeck.Validator
         private void LogicForRootObject(GameObject rootObject)
         {
             var rootTransform = rootObject.transform;
+
+            var rootTransformMemory = BoundsIndicators.TransformMemory.SaveAndReset(rootTransform);
+
             var limitFromRoot = new Bounds(limit.center + rootTransform.position, limit.size);
 
             var exceeds = rootObject
@@ -115,6 +118,8 @@ namespace VitDeck.Validator
 
                 AddIssue(new Issue(exceed.objectReference, IssueLevel.Error, message));
             }
+
+            rootTransformMemory.Apply(rootTransform);
         }
 
         private bool IsExceeded(Bounds bounds, Bounds limit)

--- a/VitDeck/Assets/VitDeck/Validator/Rules/VitDeck.Validator.Rules.asmdef
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/VitDeck.Validator.Rules.asmdef
@@ -2,7 +2,8 @@
     "name": "VitDeck.Validator.Rules",
     "references": [
         "VitDeck.Utilities",
-        "VitDeck.Validator.Components"
+        "VitDeck.Validator.Components",
+        "VitDeck.Validator.Runtime"
     ],
     "includePlatforms": [
         "Editor"

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
@@ -13,5 +13,13 @@ namespace VitDeck.Validator
                 return "Vket4 - AvatarShowcase";
             }
         }
+
+        protected override Vector3 BoothSizeLimit
+        {
+            get
+            {
+                return new Vector3(2, 2.5f, 2);
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
@@ -13,5 +13,13 @@ namespace VitDeck.Validator
                 return "Vket4 - ConceptWorld";
             }
         }
+
+        protected override Vector3 BoothSizeLimit
+        {
+            get
+            {
+                return new Vector3(4, 5, 4);
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
@@ -13,5 +13,13 @@ namespace VitDeck.Validator
                 return "Vket4 - DefaultCube";
             }
         }
+
+        protected override Vector3 BoothSizeLimit
+        {
+            get
+            {
+                return new Vector3(10, 10, 10);
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -34,9 +34,11 @@ namespace VitDeck.Validator
                 new AssetPathLengthRule("[B-3]ファイルパスはAsset/から数えて184文字以内に収まっていること", 184),
 
                 new BoothBoundsRule("[D-1,2]ブースサイズは規定の範囲内に収めること",
-                    size: new Vector3(4,5,4),
+                    size: BoothSizeLimit,
                     margin: 0.01f),
-        };
+            };
+        }
+
+        protected abstract Vector3 BoothSizeLimit { get; }
     }
-}
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace VitDeck.Validator
 {
     /// <summary>
@@ -31,8 +33,10 @@ namespace VitDeck.Validator
 
                 new AssetPathLengthRule("[B-3]ファイルパスはAsset/から数えて184文字以内に収まっていること", 184),
 
-
-            };
-        }
+                new BoothBoundsRule("[D-1,2]ブースサイズは規定の範囲内に収めること",
+                    size: new Vector3(4,5,4),
+                    margin: 0.01f),
+        };
     }
+}
 }

--- a/VitDeck/Assets/VitDeck/Validator/Runtime.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3409bd7c506c5b429419c6736050d13
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8436687e4350b9548af4bf98829a922e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    [ExecuteInEditMode]
+    public class BoothRangeIndicator : MonoBehaviour, IBoothBoundsProvider
+    {
+        [System.NonSerialized]
+        bool initialized = false;
+
+        private Bounds bounds;
+
+        public void Initialize(Bounds bounds, ResetToken token)
+        {
+            this.bounds = bounds;
+            if (token != null)
+            {
+                token.Reset += Token_Reset;
+            }
+            initialized = true;
+        }
+
+        private void Token_Reset()
+        {
+            SafeDestroy();
+        }
+
+        private void Update()
+        {
+            if (!initialized)
+            {
+                SafeDestroy();
+            }
+        }
+
+        private void SafeDestroy()
+        {
+            if (Application.isPlaying)
+            {
+                Destroy(this);
+            }
+            else
+            {
+                DestroyImmediate(this);
+            }
+        }
+
+        public Bounds GetBounds()
+        {
+            return GetActiveBounds();
+        }
+
+        private void OnDrawGizmos()
+        {
+            var activeBounds = GetActiveBounds();
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireCube(activeBounds.center, activeBounds.size);
+        }
+
+        Bounds GetActiveBounds()
+        {
+            var activeBounds = bounds;
+            activeBounds.center = activeBounds.center + transform.position;
+            return activeBounds;
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace VitDeck.Validator.BoundsIndicators
 {
     [ExecuteInEditMode]
-    public class BoothRangeIndicator : MonoBehaviour, IBoothBoundsProvider
+    public class BoothRangeIndicator : MonoBehaviour, IBoothRoot
     {
         [System.NonSerialized]
         bool initialized = false;
@@ -56,14 +56,41 @@ namespace VitDeck.Validator.BoundsIndicators
         {
             var activeBounds = GetActiveBounds();
             Gizmos.color = Color.green;
+            Gizmos.matrix = GetLocalToWorld();
             Gizmos.DrawWireCube(activeBounds.center, activeBounds.size);
         }
 
         Bounds GetActiveBounds()
         {
-            var activeBounds = bounds;
-            activeBounds.center = activeBounds.center + transform.position;
-            return activeBounds;
+            //var activeBounds = bounds;
+            //activeBounds.center = activeBounds.center + transform.position;
+            return bounds;
+        }
+
+        public Matrix4x4 GetWorldToLocal()
+        {
+            return transform.worldToLocalMatrix;
+        }
+
+        public Matrix4x4 GetLocalToWorld()
+        {
+            return transform.localToWorldMatrix;
+        }
+
+        private TransformMemory memory = null;
+
+        public void ClearTransformTemporarily()
+        {
+            if (memory == null)
+            {
+                memory = TransformMemory.SaveAndReset(transform);
+            }
+        }
+
+        public void RestorePosition()
+        {
+            memory.Apply(transform);
+            memory = null;
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ca6388f2eb7b124c9822f0ec18507ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    public interface IBoothBoundsProvider
+    {
+        Bounds GetBounds();
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs
@@ -1,9 +1,15 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace VitDeck.Validator.BoundsIndicators
 {
-    public interface IBoothBoundsProvider
+    public interface IBoothRoot
     {
         Bounds GetBounds();
+        Matrix4x4 GetWorldToLocal();
+        Matrix4x4 GetLocalToWorld();
+
+        void ClearTransformTemporarily();
+        void RestorePosition();
+
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/IBoothBoundsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff83b2b8a00549b44917c8d655d8d986
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs
@@ -1,0 +1,146 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    [ExecuteInEditMode]
+    public class RendererRangeOutIndicator : MonoBehaviour
+    {
+        [System.NonSerialized]
+        bool initialized = false;
+
+        Renderer targetRenderer;
+        private IBoothBoundsProvider booth;
+
+        public void Initialize(IBoothBoundsProvider booth, Renderer targetRenderer, ResetToken token)
+        {
+            if(booth == null)
+            {
+                throw new System.ArgumentNullException("booth");
+            }
+            if(targetRenderer == null)
+            {
+                throw new System.ArgumentNullException("targetRenderer");
+            }
+
+            this.booth = booth;
+            this.targetRenderer = targetRenderer;
+            if(token != null)
+            {
+                token.Reset += Token_Reset;
+            }
+            initialized = true;
+        }
+
+        private void Token_Reset()
+        {
+            SafeDestroy();
+        }
+
+        private void Update()
+        {
+            if(!initialized)
+            {
+                SafeDestroy();
+            }
+        }
+
+        private void SafeDestroy()
+        {
+            if (Application.isPlaying)
+            {
+                Destroy(this);
+            }
+            else
+            {
+                DestroyImmediate(this);
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (booth == null || targetRenderer == null)
+            {
+                return;
+            }
+
+            var bounds = targetRenderer.bounds;
+
+            DrawBoundsGizmos(ref bounds);
+            DrawOverhangGizmos(ref bounds);
+        }
+
+        private void DrawBoundsGizmos(ref Bounds bounds)
+        {
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireCube(bounds.center, bounds.size);
+        }
+
+        private void DrawOverhangGizmos(ref Bounds bounds)
+        {
+            var limit = booth.GetBounds();
+            Gizmos.color = Color.red;
+
+            if (limit.max.x < bounds.max.x)
+            {
+                var overed = bounds;
+                var overedMin = overed.min;
+                overedMin.x = Mathf.Max(limit.max.x, bounds.min.x);
+                overed.min = overedMin;
+
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+
+            if (limit.max.y < bounds.max.y)
+            {
+                var overed = bounds;
+                var overedMin = overed.min;
+                overedMin.y = Mathf.Max(limit.max.y, bounds.min.y);
+                overed.min = overedMin;
+
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+
+            if (limit.max.z < bounds.max.z)
+            {
+                var overed = bounds;
+                var overedMin = overed.min;
+                overedMin.z = Mathf.Max(limit.max.z, bounds.min.z);
+                overed.min = overedMin;
+
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+
+            if (limit.min.x > bounds.min.x)
+            {
+                var overed = bounds;
+                var overedMax = overed.max;
+                overedMax.x = Mathf.Min(limit.min.x, bounds.max.x);
+                overed.max = overedMax;
+
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+
+            if (limit.min.y > bounds.min.y)
+            {
+                var overed = bounds;
+                var overedMax = overed.max;
+                overedMax.y = Mathf.Min(limit.min.y, bounds.max.y);
+                overed.max = overedMax;
+                
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+
+            if (limit.min.z > bounds.min.z)
+            {
+                var overed = bounds;
+                var overedMax = overed.max;
+                overedMax.z = Mathf.Min(limit.min.z, bounds.max.z);
+                overed.max = overedMax;
+
+                Gizmos.DrawCube(overed.center, overed.size);
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs
@@ -11,22 +11,22 @@ namespace VitDeck.Validator.BoundsIndicators
         bool initialized = false;
 
         Renderer targetRenderer;
-        private IBoothBoundsProvider booth;
+        private IBoothRoot booth;
 
-        public void Initialize(IBoothBoundsProvider booth, Renderer targetRenderer, ResetToken token)
+        public void Initialize(IBoothRoot booth, Renderer targetRenderer, ResetToken token)
         {
-            if(booth == null)
+            if (booth == null)
             {
                 throw new System.ArgumentNullException("booth");
             }
-            if(targetRenderer == null)
+            if (targetRenderer == null)
             {
                 throw new System.ArgumentNullException("targetRenderer");
             }
 
             this.booth = booth;
             this.targetRenderer = targetRenderer;
-            if(token != null)
+            if (token != null)
             {
                 token.Reset += Token_Reset;
             }
@@ -40,7 +40,7 @@ namespace VitDeck.Validator.BoundsIndicators
 
         private void Update()
         {
-            if(!initialized)
+            if (!initialized || targetRenderer == null)
             {
                 SafeDestroy();
             }
@@ -65,7 +65,9 @@ namespace VitDeck.Validator.BoundsIndicators
                 return;
             }
 
+            booth.ClearTransformTemporarily();
             var bounds = targetRenderer.bounds;
+            booth.RestorePosition();
 
             DrawBoundsGizmos(ref bounds);
             DrawOverhangGizmos(ref bounds);
@@ -73,6 +75,7 @@ namespace VitDeck.Validator.BoundsIndicators
 
         private void DrawBoundsGizmos(ref Bounds bounds)
         {
+            Gizmos.matrix = booth.GetLocalToWorld();
             Gizmos.color = Color.green;
             Gizmos.DrawWireCube(bounds.center, bounds.size);
         }
@@ -80,6 +83,7 @@ namespace VitDeck.Validator.BoundsIndicators
         private void DrawOverhangGizmos(ref Bounds bounds)
         {
             var limit = booth.GetBounds();
+            Gizmos.matrix = booth.GetLocalToWorld();
             Gizmos.color = Color.red;
 
             if (limit.max.x < bounds.max.x)
@@ -128,7 +132,7 @@ namespace VitDeck.Validator.BoundsIndicators
                 var overedMax = overed.max;
                 overedMax.y = Mathf.Min(limit.min.y, bounds.max.y);
                 overed.max = overedMax;
-                
+
                 Gizmos.DrawCube(overed.center, overed.size);
             }
 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/RendererRangeOutIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61a91fd6b14a4c74d8def021d6ac569b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetToken.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetToken.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    public class ResetToken
+    {
+        private bool invoked = false;
+        public event Action Reset;
+
+        protected void Invoke()
+        {
+            if (invoked)
+            {
+                return;
+            }
+
+            if (Reset != null)
+            {
+                Reset.Invoke();
+            }
+
+            invoked = true;
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetToken.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetToken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed421118c3b307d45a120e16c922b98a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetTokenSource.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetTokenSource.cs
@@ -1,0 +1,32 @@
+﻿namespace VitDeck.Validator.BoundsIndicators
+{
+    public class ResetTokenSource
+    {
+        private readonly InternalResetToken token;
+        public ResetToken Token
+        {
+            get
+            {
+                return token;
+            }
+        }
+
+        public ResetTokenSource()
+        {
+            token = new InternalResetToken();
+        }
+
+        public void Reset()
+        {
+            token.InvokeEvent();
+        }
+
+        private class InternalResetToken : ResetToken
+        {
+            public void InvokeEvent()
+            {
+                base.Invoke();
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetTokenSource.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/ResetTokenSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1aa83c466a8ea1e4ba2e7f307c221a3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformMemory.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformMemory.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    public class TransformMemory
+    {
+        private Transform memoryParent;
+        private Vector3 memoryPosition;
+        private Quaternion memoryRotation;
+        private Vector3 memoryScale;
+
+        public static TransformMemory SaveAndReset(Transform transform)
+        {
+            var memory = new TransformMemory(transform);
+
+            transform.SetParent(null, worldPositionStays: false);
+            transform.localPosition = Vector3.zero;
+            transform.localRotation = Quaternion.identity;
+            transform.localScale = Vector3.one;
+
+            return memory;
+        }
+
+        public TransformMemory(Transform transform)
+        {
+            memoryParent = transform.parent;
+            memoryPosition = transform.localPosition;
+            memoryRotation = transform.localRotation;
+            memoryScale = transform.localScale;
+        }
+
+        public void Apply(Transform target)
+        {
+            target.SetParent(memoryParent, worldPositionStays: false);
+            target.localPosition = memoryPosition;
+            target.localRotation = memoryRotation;
+            target.localScale = memoryScale;
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformMemory.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformMemory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4919afe7ffcff8544bc0a71dc7451fc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs
@@ -10,9 +10,9 @@ namespace VitDeck.Validator.BoundsIndicators
         [System.NonSerialized]
         private bool initialized = false;
 
-        private IBoothBoundsProvider booth;
+        private IBoothRoot booth;
 
-        public void Initialize(IBoothBoundsProvider booth, ResetToken token)
+        public void Initialize(IBoothRoot booth, ResetToken token)
         {
             if (booth == null)
             {
@@ -20,7 +20,7 @@ namespace VitDeck.Validator.BoundsIndicators
             }
 
             this.booth = booth;
-            if(token != null)
+            if (token != null)
             {
                 token.Reset += Token_Reset;
             }
@@ -60,13 +60,13 @@ namespace VitDeck.Validator.BoundsIndicators
             }
 
             var limit = booth.GetBounds();
-            if (limit.Contains(transform.position))
+            var localPosition = booth.GetWorldToLocal().MultiplyPoint3x4(transform.position);
+            if (limit.Contains(localPosition))
             {
                 return;
             }
 
             Gizmos.color = Color.red;
-
             Gizmos.DrawSphere(transform.position, 0.1f);
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VitDeck.Validator.BoundsIndicators
+{
+    [ExecuteInEditMode]
+    public class TransformRangeOutIndicator : MonoBehaviour
+    {
+        [System.NonSerialized]
+        private bool initialized = false;
+
+        private IBoothBoundsProvider booth;
+
+        public void Initialize(IBoothBoundsProvider booth, ResetToken token)
+        {
+            if (booth == null)
+            {
+                throw new System.ArgumentNullException("booth");
+            }
+
+            this.booth = booth;
+            if(token != null)
+            {
+                token.Reset += Token_Reset;
+            }
+            initialized = true;
+        }
+
+        private void Token_Reset()
+        {
+            SafeDestroy();
+        }
+
+        private void Update()
+        {
+            if (!initialized)
+            {
+                SafeDestroy();
+            }
+        }
+
+        private void SafeDestroy()
+        {
+            if (Application.isPlaying)
+            {
+                Destroy(this);
+            }
+            else
+            {
+                DestroyImmediate(this);
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (booth == null)
+            {
+                return;
+            }
+
+            var limit = booth.GetBounds();
+            if (limit.Contains(transform.position))
+            {
+                return;
+            }
+
+            Gizmos.color = Color.red;
+
+            Gizmos.DrawSphere(transform.position, 0.1f);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/BoundsIndicators/TransformRangeOutIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af1597e2617a95e4a9d30a3020a864ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/VitDeck.Validator.Runtime.asmdef
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/VitDeck.Validator.Runtime.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "VitDeck.Validator.Runtime"
+}

--- a/VitDeck/Assets/VitDeck/Validator/Runtime/VitDeck.Validator.Runtime.asmdef.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Runtime/VitDeck.Validator.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 302dedb10dfafbc4890a8bb3a14666c6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B01_TestBoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B01_TestBoothBoundsRule.cs
@@ -22,8 +22,16 @@ namespace VitDeck.Validator.Test
                 CreateRectGameObject("TestTargetObject5", true, new Vector3(0, 1, 0), new Vector2(2, 2) ),
                 CreateRectGameObject("TestTargetObject6", false, new Vector3(1000, 1, 0), new Vector2(2, 2) ),
             };
+            var rootObject = CreateSimpleGameObject("TestTargetRootObject", true, Vector3.zero);
+            foreach (var target in targetObjects)
+            {
+                target.transform.SetParent(rootObject.transform, false);
+            }
 
-            targetContainer = new ValidationTarget("Assets/VitDeck/Validator/Tests", allObjects: targetObjects);
+            targetContainer = new ValidationTarget(
+                "Assets/VitDeck/Validator/Tests",
+                allObjects: targetObjects,
+                rootObjects: new GameObject[] { rootObject });
         }
 
         public static readonly object[] TestCases =

--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+using VitDeck.Validator.BoundsIndicators;
+
+namespace VitDeck.Validator.Test
+{
+    [TestFixture(TestOf = typeof(ResetTokenSource))]
+    public class TestResetTokenSource
+    {
+        [Test]
+        private void Test()
+        {
+            var tokenSource = new ResetTokenSource();
+
+            var token = tokenSource.Token;
+
+            bool isCalled = false;
+
+            token.Reset += () => isCalled = true;
+
+            tokenSource.Reset();
+
+            Assert.IsTrue(isCalled);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs
@@ -10,7 +10,7 @@ namespace VitDeck.Validator.Test
     public class TestResetTokenSource
     {
         [Test]
-        private void Test()
+        public void Test()
         {
             var tokenSource = new ResetTokenSource();
 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestResetTokenSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c9bbcfa20246cf4dbdaa75f0735457d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestTransformMemory.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestTransformMemory.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NUnit.Framework;
+using VitDeck.Validator.BoundsIndicators;
+
+namespace VitDeck.Validator.Test
+{
+    [TestFixture(TestOf = typeof(TransformMemory))]
+    public class TestTransformMemory
+    {
+        [Test]
+        public void MemoryTest()
+        {
+            var parentObject = new GameObject("TestTransformMemory-ParentObject");
+            var gameObject0 = new GameObject("TestTransformMemory-GameObject0");
+            var gameObject1 = new GameObject("TestTransformMemory-GameObject1");
+            Transform transform0 = gameObject0.transform;
+            Transform transform1 = gameObject1.transform;
+
+            transform0.SetParent(parentObject.transform);
+            transform0.position = new Vector3(1, 2, 3);
+            transform0.rotation = Quaternion.Euler(1f, 2f, 3f);
+            transform0.localScale = new Vector3(4, 5, 6);
+            var memory = new TransformMemory(transform0);
+
+            memory.Apply(transform1);
+
+            Assert.AreEqual(transform0.parent, transform1.parent);
+            Assert.AreEqual(transform0.position, transform1.position);
+            Assert.AreEqual(transform0.rotation, transform1.rotation);
+            Assert.AreEqual(transform0.localScale, transform1.localScale);
+        }
+
+        [Test]
+        public void ResetTest()
+        {
+            var parentObject = new GameObject("TestTransformMemory-ParentObject");
+            var gameObject = new GameObject("TestTransformMemory-GameObject");
+            var transform = gameObject.transform;
+
+            transform.SetParent(parentObject.transform);
+            transform.position = new Vector3(1, 2, 3);
+            transform.rotation = Quaternion.Euler(1f, 2f, 3f);
+            transform.localScale = new Vector3(4, 5, 6);
+
+            var memory = TransformMemory.SaveAndReset(gameObject.transform);
+
+            Assert.IsNull(transform.parent);
+            Assert.AreEqual(Vector3.zero, gameObject.transform.position);
+            Assert.AreEqual(Quaternion.identity, gameObject.transform.rotation);
+            Assert.AreEqual(Vector3.one, gameObject.transform.localScale);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestTransformMemory.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestTransformMemory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3039e3fb5efb4f4aa91293da77c369b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/VitDeck.Validator.Tests.asmdef
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/VitDeck.Validator.Tests.asmdef
@@ -4,7 +4,8 @@
         "VitDeck.Validator",
         "VitDeck.TestUtilities",
         "VitDeck.Validator.Components",
-        "VitDeck.Validator.Rules"
+        "VitDeck.Validator.Rules",
+        "VitDeck.Validator.Runtime"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
ブース範囲制限ルールを作成しました。基本はB01_BoothBoundsRuleをベースにしつつ機能追加、不具合修正を行っています。

- 制限値をワールド別で切り替えられるようRuleSetに抽象プロパティを定義
- ブースの回転に対応していない不具合を修正
- 範囲外に出ているオブジェクトにGizmoを付ける機能を追加

一つ解決できていない課題として、Gizmoを表示するために検証中にGameObjectに非表示のコンポーネントをアタッチするのですが、検証終了後にブースに対してUndo処理が行われ、その際に警告が出てしまいます。ただしこの警告に従うとGizmo用コンポーネントが消されてしまうので、現状そのままにしてあります。
![image](https://user-images.githubusercontent.com/7193342/71559975-72abfb00-2aa7-11ea-9783-968d6aa4b207.png)
