### PR TITLE
Feature/f01 light config rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
@@ -29,5 +29,33 @@ namespace VitDeck.Validator
                 return 0;
             }
         }
+        
+        protected override LightConfigRule.LightConfig ApprovedPointLightConfig
+        {
+            get
+            {
+                // エラー項目がでないダミー検証
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+            }
+        }
+        protected override LightConfigRule.LightConfig ApprovedSpotLightConfig
+        {
+            get
+            {
+                // エラー項目がでないダミー検証
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+            }
+        }
+        protected override LightConfigRule.LightConfig ApprovedAreaLightConfig
+        {
+            get
+            {
+                // エラー項目がでないダミー検証
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
@@ -34,27 +34,21 @@ namespace VitDeck.Validator
         {
             get
             {
-                // エラー項目がでないダミー検証
-                return new LightConfigRule.LightConfig(
-                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+                return new LightConfigRule.LightConfig(new LightmapBakeType[] { });
             }
         }
         protected override LightConfigRule.LightConfig ApprovedSpotLightConfig
         {
             get
             {
-                // エラー項目がでないダミー検証
-                return new LightConfigRule.LightConfig(
-                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+                return new LightConfigRule.LightConfig(new LightmapBakeType[] { });
             }
         }
         protected override LightConfigRule.LightConfig ApprovedAreaLightConfig
         {
             get
             {
-                // エラー項目がでないダミー検証
-                return new LightConfigRule.LightConfig(
-                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime, LightmapBakeType.Mixed });
+                return new LightConfigRule.LightConfig(new LightmapBakeType[] { });
             }
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
@@ -29,5 +29,40 @@ namespace VitDeck.Validator
                 return 3;
             }
         }
+        protected override LightConfigRule.LightConfig ApprovedPointLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime },
+                            0, 7,
+                            0, 10,
+                            0, 15);
+            }
+        }
+
+        protected override LightConfigRule.LightConfig ApprovedSpotLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime },
+                            0, 7,
+                            0, 10,
+                            0, 15);
+            }
+        }
+
+        protected override LightConfigRule.LightConfig ApprovedAreaLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked },
+                            0, 30,
+                            0, 10,
+                            0, 15);
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 namespace VitDeck.Validator
 {
@@ -27,6 +28,33 @@ namespace VitDeck.Validator
             get
             {
                 return 3;
+            }
+        }
+
+        protected override LightConfigRule.LightConfig ApprovedPointLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new [] { LightmapBakeType.Baked, LightmapBakeType.Realtime });
+            }
+        }
+
+        protected override LightConfigRule.LightConfig ApprovedSpotLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime });
+            }
+        }
+
+        protected override LightConfigRule.LightConfig ApprovedAreaLightConfig
+        {
+            get
+            {
+                return new LightConfigRule.LightConfig(
+                            new[] { LightmapBakeType.Baked });
             }
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
@@ -77,6 +77,17 @@ namespace VitDeck.Validator
 
         private void LogicForLight(Light light)
         {
+            if (approvedLightmapBakeTypes.Length <= 0)
+            {
+                AddIssue(new Issue(
+                    light.gameObject,
+                    IssueLevel.Error,
+                    string.Format("{0}Lightは使用できません。", light.type),
+                    "削除するかModeを変更して他のLightを使用して下さい。"));
+
+                return;
+            }
+
             if (!approvedLightmapBakeTypes.Contains(light.lightmapBakeType))
             {
                 AddIssue(new Issue(

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
@@ -43,6 +43,22 @@ namespace VitDeck.Validator
             this.maxBounceIntensity = maxBounceIntensity;
         }
 
+        public LightConfigRule(
+            string name,
+            LightType type,
+            LightConfig approvedConfig
+        ) : base(name)
+        {
+            this.type = type;
+            this.approvedLightmapBakeTypes = approvedConfig.bakeTypes;
+            this.minRange = approvedConfig.minRange;
+            this.maxRange = approvedConfig.maxRange;
+            this.minIntensity = approvedConfig.minIntensity;
+            this.maxIntensity = approvedConfig.maxIntensity;
+            this.minBounceIntensity = approvedConfig.minBounceIntensity;
+            this.maxBounceIntensity = approvedConfig.maxBounceIntensity;
+        }
+
         protected override void Logic(ValidationTarget target)
         {
             var objs = target.GetAllObjects();
@@ -112,6 +128,32 @@ namespace VitDeck.Validator
                         string.Format("Indirect Multiplierを範囲内になるように設定して下さい。")
                         ));
                 }
+            }
+        }
+
+        public class LightConfig
+        {
+            public LightmapBakeType[] bakeTypes { get; private set; }
+            public float minRange { get; private set; }
+            public float maxRange { get; private set; }
+            public float minIntensity { get; private set; }
+            public float maxIntensity { get; private set; }
+            public float minBounceIntensity { get; private set; }
+            public float maxBounceIntensity { get; private set; }
+
+            public LightConfig(
+                LightmapBakeType[] bakeTypes,
+                float minRange = NO_LIMIT, float maxRange = NO_LIMIT, 
+                float minIntensity = NO_LIMIT, float maxIntensity = NO_LIMIT, 
+                float minBounceIntensity = NO_LIMIT, float maxBounceIntensity = NO_LIMIT)
+            {
+                this.bakeTypes = bakeTypes;
+                this.minRange = minRange;
+                this.maxRange = maxRange;
+                this.minIntensity = minIntensity;
+                this.maxIntensity = maxIntensity;
+                this.minBounceIntensity = minBounceIntensity;
+                this.maxBounceIntensity = maxBounceIntensity;
             }
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace VitDeck.Validator
+{
+    /// <summary>
+    /// 特定のLightの設定が制限に従っていることを検証するルール
+    /// </summary>
+    public class LightConfigRule : BaseRule
+    {
+        public const float NO_LIMIT = -1;
+
+        private LightType type;
+        private readonly LightmapBakeType[] approvedLightmapBakeTypes;
+        private readonly float minRange;
+        private readonly float maxRange;
+        private readonly float minIntensity;
+        private readonly float maxIntensity;
+        private readonly float minBounceIntensity;
+        private readonly float maxBounceIntensity;
+
+        private string bakeTypeListString;
+
+        public LightConfigRule(
+                string name,
+                LightType type,
+                LightmapBakeType[] approvedLightmapBakeTypes,
+                float minRange = NO_LIMIT, float maxRange = NO_LIMIT,
+                float minIntensity = NO_LIMIT, float maxIntensity = NO_LIMIT,
+                float minBounceIntensity = NO_LIMIT, float maxBounceIntensity = NO_LIMIT
+        ) : base(name)
+        {
+            this.type = type;
+            this.approvedLightmapBakeTypes = approvedLightmapBakeTypes;
+            this.minRange = minRange;
+            this.maxRange = maxRange;
+            this.minIntensity = minIntensity;
+            this.maxIntensity = maxIntensity;
+            this.minBounceIntensity = minBounceIntensity;
+            this.maxBounceIntensity = maxBounceIntensity;
+        }
+
+        protected override void Logic(ValidationTarget target)
+        {
+            var objs = target.GetAllObjects();
+
+            bakeTypeListString = string.Join(", ", approvedLightmapBakeTypes.Select(x => x.ToString()).ToArray());
+
+            foreach (var obj in objs)
+            {
+                var light = obj.GetComponent<Light>();
+                if (light != null && light.type == type)
+                {
+                    LogicForLight(light);
+                }
+            }
+        }
+
+        private void LogicForLight(Light light)
+        {
+            if (!approvedLightmapBakeTypes.Contains(light.lightmapBakeType))
+            {
+                AddIssue(new Issue(
+                    light.gameObject, 
+                    IssueLevel.Error, 
+                    string.Format("{0}LightのModeが{1}以外に設定されています。({2})", 
+                        light.type, bakeTypeListString, light.lightmapBakeType),
+                    string.Format("Modeを{0}に設定して下さい。", bakeTypeListString)
+                    ));
+            }
+
+            if (minRange != NO_LIMIT && maxRange != NO_LIMIT)
+            {
+                if (light.range < minRange || light.range > maxRange)
+                {
+                    AddIssue(new Issue(
+                        light.gameObject,
+                        IssueLevel.Error,
+                        string.Format("{0}LightのRangeが{1}～{2}の範囲を超えています。(設定値：{3})", 
+                            light.type, minRange, maxRange, light.range),
+                        string.Format("Rangeを範囲内になるように設定して下さい。")
+                        ));
+                }
+            }
+
+            if (minIntensity != NO_LIMIT && maxIntensity != NO_LIMIT)
+            {
+                if (light.intensity < minIntensity || light.intensity > maxIntensity)
+                {
+                    AddIssue(new Issue(
+                        light.gameObject,
+                        IssueLevel.Error,
+                        string.Format("{0}LightのIntensityが{1}～{2}の範囲を超えています。(設定値：{3})", 
+                            light.type, minIntensity, maxIntensity, light.intensity),
+                        string.Format("Intensityを範囲内になるように設定して下さい。")
+                        ));
+                }
+            }
+
+            if (minBounceIntensity != NO_LIMIT && maxBounceIntensity != NO_LIMIT)
+            {
+                if (light.bounceIntensity < minBounceIntensity || light.bounceIntensity > maxBounceIntensity)
+                {
+                    AddIssue(new Issue(
+                        light.gameObject,
+                        IssueLevel.Error,
+                        string.Format("{0}LightのIndirect Multiplierが{1}～{2}の範囲を超えています。(設定値：{3})",
+                            light.type, minBounceIntensity, maxBounceIntensity, light.bounceIntensity),
+                        string.Format("Indirect Multiplierを範囲内になるように設定して下さい。")
+                        ));
+                }
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs
@@ -83,7 +83,7 @@ namespace VitDeck.Validator
                     light.gameObject,
                     IssueLevel.Error,
                     string.Format("{0}Lightは使用できません。", light.type),
-                    "削除するかModeを変更して他のLightを使用して下さい。"));
+                    "削除するかTypeを変更して他のLightを使用して下さい。"));
 
                 return;
             }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_LightConfigRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58a5a58d7c8f18843a97e38cbbec5369
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -55,6 +55,12 @@ namespace VitDeck.Validator
 
                 new LightCountLimitRule("[F-1]DirectionalLightを使用しないこと", UnityEngine.LightType.Directional, 0),
 
+                new LightConfigRule("[F-1]PointLightの設定が制限に従っていること", UnityEngine.LightType.Point, ApprovedPointLightConfig),
+
+                new LightConfigRule("[F-1]SpotLightの設定が制限に従っていること", UnityEngine.LightType.Spot, ApprovedSpotLightConfig),
+
+                new LightConfigRule("[F-1]AreaLightの設定が制限に従っていること", UnityEngine.LightType.Point, ApprovedAreaLightConfig),
+
                 new LightCountLimitRule(
                     string.Format("[F-1]AreaLightの使用数が{0}個以下であること", AreaLightUsesLimit),
                     UnityEngine.LightType.Area,
@@ -67,5 +73,10 @@ namespace VitDeck.Validator
         
         protected abstract int MaterialUsesLimit { get; }
         
+        protected abstract LightConfigRule.LightConfig ApprovedPointLightConfig { get; }
+
+        protected abstract LightConfigRule.LightConfig ApprovedSpotLightConfig { get; }
+
+        protected abstract LightConfigRule.LightConfig ApprovedAreaLightConfig { get; }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -59,7 +59,7 @@ namespace VitDeck.Validator
 
                 new LightConfigRule("[F-1]SpotLightの設定が制限に従っていること", UnityEngine.LightType.Spot, ApprovedSpotLightConfig),
 
-                new LightConfigRule("[F-1]AreaLightの設定が制限に従っていること", UnityEngine.LightType.Point, ApprovedAreaLightConfig),
+                new LightConfigRule("[F-1]AreaLightの設定が制限に従っていること", UnityEngine.LightType.Area, ApprovedAreaLightConfig),
 
                 new LightCountLimitRule(
                     string.Format("[F-1]AreaLightの使用数が{0}個以下であること", AreaLightUsesLimit),

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c4f9b3f4bc973043a2647715867b851
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule/New Scene.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule/New Scene.unity
@@ -1,0 +1,651 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &15946670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 15946672}
+  - component: {fileID: 15946671}
+  m_Layer: 0
+  m_Name: Spotlight_OK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &15946671
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15946670}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 10
+  m_Range: 7
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 15
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &15946672
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15946670}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &18237351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 18237353}
+  - component: {fileID: 18237352}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &18237352
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 18237351}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &18237353
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 18237351}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &130983455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 130983459}
+  - component: {fileID: 130983458}
+  - component: {fileID: 130983457}
+  - component: {fileID: 130983456}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &130983456
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 130983455}
+  m_Enabled: 1
+--- !u!124 &130983457
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 130983455}
+  m_Enabled: 1
+--- !u!20 &130983458
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 130983455}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &130983459
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 130983455}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1155350421
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1155350423}
+  - component: {fileID: 1155350422}
+  m_Layer: 0
+  m_Name: Spotlight_NG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1155350422
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1155350421}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 11
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 1
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 16
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1155350423
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1155350421}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &1289314325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1289314327}
+  - component: {fileID: 1289314326}
+  m_Layer: 0
+  m_Name: Point light_NG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1289314326
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289314325}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 2
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 15
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 1
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 20
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1289314327
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289314325}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1711618135
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1711618137}
+  - component: {fileID: 1711618136}
+  m_Layer: 0
+  m_Name: Point light_OK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1711618136
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1711618135}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 2
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 10
+  m_Range: 7
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 15
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1711618137
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1711618135}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1740541903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1740541905}
+  - component: {fileID: 1740541904}
+  m_Layer: 0
+  m_Name: Area Light_OK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1740541904
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1740541903}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 3
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 10
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 15
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1740541905
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1740541903}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &2061725493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2061725495}
+  - component: {fileID: 2061725494}
+  m_Layer: 0
+  m_Name: Area Light_NG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2061725494
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2061725493}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 3
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 11
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 2
+  m_AreaSize: {x: 2, y: 2}
+  m_BounceIntensity: 16
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2061725495
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2061725493}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule/New Scene.unity.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule/New Scene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56b8f039b74f23341b1d474459d7cb23
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs
@@ -1,0 +1,163 @@
+using NUnit.Framework;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace VitDeck.Validator.Test
+{
+    public class TestLightConfigRule
+    {
+        [TestCase(LightType.Point, new[] { LightmapBakeType.Baked, LightmapBakeType.Mixed })]
+        [TestCase(LightType.Spot, new[] { LightmapBakeType.Baked, LightmapBakeType.Mixed })]
+        [TestCase(LightType.Area, new [] { LightmapBakeType.Baked })]
+        public void TestValidate(LightType type, LightmapBakeType[] bakeTypes)
+        {
+            var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), type, bakeTypes);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
+            var result = rule.Validate(target);
+
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
+            Debug.Log(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type));
+            Assert.That(result.Issues.Count, Is.EqualTo(0));
+        }
+
+        [TestCase(LightType.Point, new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime })]
+        [TestCase(LightType.Spot, new[] { LightmapBakeType.Baked, LightmapBakeType.Realtime })]
+        public void TestValidateErrorBakeType(LightType type, LightmapBakeType[] bakeTypes)
+        {
+            var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), type, bakeTypes);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
+            var result = rule.Validate(target);
+
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
+            Debug.Log(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type));
+            Assert.That(result.Issues.Count, Is.EqualTo(1));
+
+            var obj = result.Issues[0].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            var light = obj.GetComponent<Light>();
+            var bakeTypeListString = string.Join(", ", bakeTypes.Select(x => x.ToString()).ToArray());
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}LightのModeが{1}以外に設定されています。({2})",
+                                                                type, bakeTypeListString, light.lightmapBakeType)));
+            Assert.That(result.Issues[0].solution, Is.EqualTo(string.Format("Modeを{0}に設定して下さい。", bakeTypeListString)));
+            Debug.Log(result.Issues[0].message);
+            Debug.Log(result.Issues[0].solution);
+        }
+
+        [TestCase(LightType.Point, new [] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
+        [TestCase(LightType.Spot, new [] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
+        public void TestValidateErrorDetail(
+            LightType type, 
+            LightmapBakeType[] bakeTypes, 
+            float minRange, float maxRange, 
+            float minIntensity, float maxIntensity, 
+            float minBounceIntensity, float maxBounceIntensity)
+        {
+            var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), 
+                    type, bakeTypes, minRange, maxRange, minIntensity, maxIntensity, minBounceIntensity, maxBounceIntensity);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
+            var result = rule.Validate(target);
+
+            Assert.That(result.RuleName,Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
+            Debug.Log(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type));
+            Assert.That(result.Issues.Count, Is.EqualTo(4));
+
+            var obj = result.Issues[0].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            var light = obj.GetComponent<Light>();
+            var bakeTypeListString = string.Join(", ", bakeTypes.Select(x => x.ToString()).ToArray());
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}LightのModeが{1}以外に設定されています。({2})", 
+                                                                type, bakeTypeListString, light.lightmapBakeType)));
+            Assert.That(result.Issues[0].solution, Is.EqualTo(string.Format("Modeを{0}に設定して下さい。", bakeTypeListString)));
+            Debug.Log(result.Issues[0].message);
+            Debug.Log(result.Issues[0].solution);
+
+            obj = result.Issues[1].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("{0}LightのRangeが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minRange, maxRange, light.range)));
+            Assert.That(result.Issues[1].solution, Is.EqualTo("Rangeを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[1].message);
+            Debug.Log(result.Issues[1].solution);
+
+            obj = result.Issues[2].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[2].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[2].message, Is.EqualTo(string.Format("{0}LightのIntensityが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minIntensity, maxIntensity, light.intensity)));
+            Assert.That(result.Issues[2].solution, Is.EqualTo("Intensityを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[2].message);
+            Debug.Log(result.Issues[2].solution);
+
+            obj = result.Issues[3].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[3].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[3].message, Is.EqualTo(string.Format("{0}LightのIndirect Multiplierが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minBounceIntensity, maxBounceIntensity, light.bounceIntensity)));
+            Assert.That(result.Issues[3].solution, Is.EqualTo("Indirect Multiplierを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[3].message);
+            Debug.Log(result.Issues[3].solution);
+        }
+
+        [TestCase(LightType.Area, new[] { LightmapBakeType.Baked }, 0, 30, 0, 10, 0, 15)]
+        public void TestValidateErrorAreaDetail(
+            LightType type,
+            LightmapBakeType[] bakeTypes,
+            float minRange = LightConfigRule.NO_LIMIT, float maxRange = LightConfigRule.NO_LIMIT,
+            float minIntensity = LightConfigRule.NO_LIMIT, float maxIntensity = LightConfigRule.NO_LIMIT,
+            float minBounceIntensity = LightConfigRule.NO_LIMIT, float maxBounceIntensity = LightConfigRule.NO_LIMIT)
+        {
+            var rule = (minRange == LightConfigRule.NO_LIMIT) ?
+                new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), type, bakeTypes) :
+                new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type),
+                    type, bakeTypes, minRange, maxRange, minIntensity, maxIntensity, minBounceIntensity, maxBounceIntensity);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
+            var result = rule.Validate(target);
+
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
+            Debug.Log(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type));
+            Assert.That(result.Issues.Count, Is.EqualTo(3));
+
+            var obj = result.Issues[0].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            var light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}LightのRangeが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minRange, maxRange, light.range)));
+            Assert.That(result.Issues[0].solution, Is.EqualTo("Rangeを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[0].message);
+            Debug.Log(result.Issues[0].solution);
+
+            obj = result.Issues[1].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("{0}LightのIntensityが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minIntensity, maxIntensity, light.intensity)));
+            Assert.That(result.Issues[1].solution, Is.EqualTo("Intensityを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[1].message);
+            Debug.Log(result.Issues[1].solution);
+
+            obj = result.Issues[2].target as GameObject;
+            Assert.That(obj.name, Does.EndWith("_NG"));
+            light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[2].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[2].message, Is.EqualTo(string.Format("{0}LightのIndirect Multiplierが{1}～{2}の範囲を超えています。(設定値：{3})",
+                                                                type, minBounceIntensity, maxBounceIntensity, light.bounceIntensity)));
+            Assert.That(result.Issues[2].solution, Is.EqualTo("Indirect Multiplierを範囲内になるように設定して下さい。"));
+            Debug.Log(result.Issues[2].message);
+            Debug.Log(result.Issues[2].solution);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs
@@ -10,7 +10,7 @@ namespace VitDeck.Validator.Test
     {
         [TestCase(LightType.Point, new[] { LightmapBakeType.Baked, LightmapBakeType.Mixed })]
         [TestCase(LightType.Spot, new[] { LightmapBakeType.Baked, LightmapBakeType.Mixed })]
-        [TestCase(LightType.Area, new [] { LightmapBakeType.Baked })]
+        [TestCase(LightType.Area, new[] { LightmapBakeType.Baked })]
         public void TestValidate(LightType type, LightmapBakeType[] bakeTypes)
         {
             var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), type, bakeTypes);
@@ -48,22 +48,22 @@ namespace VitDeck.Validator.Test
             Debug.Log(result.Issues[0].solution);
         }
 
-        [TestCase(LightType.Point, new [] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
-        [TestCase(LightType.Spot, new [] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
+        [TestCase(LightType.Point, new[] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
+        [TestCase(LightType.Spot, new[] { LightmapBakeType.Baked }, 0, 7, 0, 10, 0, 15)]
         public void TestValidateErrorDetail(
-            LightType type, 
-            LightmapBakeType[] bakeTypes, 
-            float minRange, float maxRange, 
-            float minIntensity, float maxIntensity, 
+            LightType type,
+            LightmapBakeType[] bakeTypes,
+            float minRange, float maxRange,
+            float minIntensity, float maxIntensity,
             float minBounceIntensity, float maxBounceIntensity)
         {
-            var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type), 
+            var rule = new LightConfigRule(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type),
                     type, bakeTypes, minRange, maxRange, minIntensity, maxIntensity, minBounceIntensity, maxBounceIntensity);
             var finder = new ValidationTargetFinder();
             var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
             var result = rule.Validate(target);
 
-            Assert.That(result.RuleName,Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type)));
             Debug.Log(string.Format("{0}Lightの設定が制限に従っていることを検証するルール", type));
             Assert.That(result.Issues.Count, Is.EqualTo(4));
 
@@ -72,7 +72,7 @@ namespace VitDeck.Validator.Test
             var light = obj.GetComponent<Light>();
             var bakeTypeListString = string.Join(", ", bakeTypes.Select(x => x.ToString()).ToArray());
             Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
-            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}LightのModeが{1}以外に設定されています。({2})", 
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}LightのModeが{1}以外に設定されています。({2})",
                                                                 type, bakeTypeListString, light.lightmapBakeType)));
             Assert.That(result.Issues[0].solution, Is.EqualTo(string.Format("Modeを{0}に設定して下さい。", bakeTypeListString)));
             Debug.Log(result.Issues[0].message);
@@ -158,6 +158,30 @@ namespace VitDeck.Validator.Test
             Assert.That(result.Issues[2].solution, Is.EqualTo("Indirect Multiplierを範囲内になるように設定して下さい。"));
             Debug.Log(result.Issues[2].message);
             Debug.Log(result.Issues[2].solution);
+        }
+
+        [Test]
+        public void TestValidateErrorUnavailable()
+        {
+            var type = LightType.Spot;
+
+            var rule = new LightConfigRule(string.Format("{0}Lightが使用されていないことを検証するルール", type), type, new LightmapBakeType[] { });
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_LightConfigRule", true);
+            var result = rule.Validate(target);
+
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}Lightが使用されていないことを検証するルール", type)));
+            Debug.Log(string.Format("{0}Lightが使用されていないことを検証するルール", type));
+            Assert.That(result.Issues.Count, Is.EqualTo(2));
+
+            foreach (var issue in result.Issues)
+            {
+                Assert.That(issue.level, Is.EqualTo(IssueLevel.Error));
+                Assert.That(issue.message, Is.EqualTo(string.Format("{0}Lightは使用できません。", type)));
+                Assert.That(issue.solution, Is.EqualTo("削除するかModeを変更して他のLightを使用して下さい。"));
+                Debug.Log(issue.message);
+                Debug.Log(issue.solution);
+            }
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestLightConfigRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3322dee51158f04cbbea9b84ac770d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
特定のLightの設定が制限に従っているか検証するルールを追加
SpotLight、PointLightおよびAreaLightの設定を確認するために使用します。
確認する項目はMode, Range, Intensity, Indirect Multipilerであり、ワールドによってその制限内容は異なります。
無制限の場合、その項目は検証する必要がないため, 上限または下限に-1(NO_LIMIT)が入力されている場合無視します。
AvatarShowcaseのみでこれらのLightは使用すら不可であるため、Modeをどれも許可しないようにするとそのLightの使用自体を許可しないルールになるようにしました