### PR TITLE
Feature/f01 use light mode rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/AvatarShowcaseRuleSet.cs
@@ -29,5 +29,21 @@ namespace VitDeck.Validator
                 return 0;
             }
         }
+
+        protected override LightmapBakeType[] unusablePointLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { };
+            }
+        }
+
+        protected override LightmapBakeType[] unusableSpotLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { };
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/ConceptWorldRuleSet.cs
@@ -29,5 +29,21 @@ namespace VitDeck.Validator
                 return 3;
             }
         }
+
+        protected override LightmapBakeType[] unusablePointLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { };
+            }
+        }
+
+        protected override LightmapBakeType[] unusableSpotLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { };
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
@@ -29,5 +29,21 @@ namespace VitDeck.Validator
                 return 3;
             }
         }
+
+        protected override LightmapBakeType[] unusablePointLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { LightmapBakeType.Realtime };
+            }
+        }
+
+        protected override LightmapBakeType[] unusableSpotLightModes
+        {
+            get
+            {
+                return new LightmapBakeType[] { LightmapBakeType.Realtime };
+            }
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/DefaultCubeRuleSet.cs
@@ -34,7 +34,7 @@ namespace VitDeck.Validator
         {
             get
             {
-                return new LightmapBakeType[] { LightmapBakeType.Realtime };
+                return new LightmapBakeType[] { LightmapBakeType.Realtime, LightmapBakeType.Mixed };
             }
         }
 
@@ -42,7 +42,7 @@ namespace VitDeck.Validator
         {
             get
             {
-                return new LightmapBakeType[] { LightmapBakeType.Realtime };
+                return new LightmapBakeType[] { LightmapBakeType.Realtime, LightmapBakeType.Mixed };
             }
         }
     }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_UseLightModeRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_UseLightModeRule.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace VitDeck.Validator
+{
+    /// <summary>
+    /// 特定のLightのModeが使用されているか検証するルール
+    /// </summary>
+    public class UseLightModeRule : BaseRule
+    {
+        private readonly LightType type;
+        private readonly LightmapBakeType[] unusableBakeTypes;
+
+        public UseLightModeRule(string name, LightType type, LightmapBakeType[] unusableBakeTypes) : base(name)
+        {
+            this.type = type;
+            this.unusableBakeTypes = unusableBakeTypes;
+        }
+
+        protected override void Logic(ValidationTarget target)
+        {
+            if (unusableBakeTypes.Length <= 0)
+            {
+                return;
+            }
+
+            var objs = target.GetAllObjects();
+
+            foreach (var obj in objs)
+            {
+                var light = obj.GetComponent<Light>();
+
+                if (light != null && light.type == type)
+                {
+                    if (unusableBakeTypes.Contains(light.lightmapBakeType))
+                    {
+                        AddIssue(new Issue(
+                            obj, 
+                            IssueLevel.Error, 
+                            string.Format("{0}Lightの{1} Modeは使用できません。", type, light.lightmapBakeType), 
+                            "使用申請をするかModeを変更して下さい。"
+                            ));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_UseLightModeRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/F01_UseLightModeRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dcfe8c348e72f941b20c7aac1a078e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -55,6 +55,10 @@ namespace VitDeck.Validator
 
                 new LightCountLimitRule("[F-1]DirectionalLightを使用しないこと", UnityEngine.LightType.Directional, 0),
 
+                new UseLightModeRule("[F-1]DefaultCubeにてPointLightでRealTimeModeを使用しないこと", UnityEngine.LightType.Point, unusablePointLightModes),
+
+                new UseLightModeRule("[F-1]DefaultCubeにてSpotLightでRealTimeModeを使用しないこと", UnityEngine.LightType.Spot, unusableSpotLightModes),
+
                 new LightCountLimitRule(
                     string.Format("[F-1]AreaLightの使用数が{0}個以下であること", AreaLightUsesLimit),
                     UnityEngine.LightType.Area,
@@ -66,6 +70,10 @@ namespace VitDeck.Validator
         protected abstract int AreaLightUsesLimit { get; }
         
         protected abstract int MaterialUsesLimit { get; }
-        
+
+        protected abstract LightmapBakeType[] unusablePointLightModes { get; }
+
+        protected abstract LightmapBakeType[] unusableSpotLightModes { get; }
+
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Vket4/Vket4RuleSetBase.cs
@@ -55,9 +55,9 @@ namespace VitDeck.Validator
 
                 new LightCountLimitRule("[F-1]DirectionalLightを使用しないこと", UnityEngine.LightType.Directional, 0),
 
-                new UseLightModeRule("[F-1]DefaultCubeにてPointLightでRealTimeModeを使用しないこと", UnityEngine.LightType.Point, unusablePointLightModes),
+                new UseLightModeRule("[F-1]DefaultCubeにてPointLightで許可されていないModeを使用しないこと", UnityEngine.LightType.Point, unusablePointLightModes),
 
-                new UseLightModeRule("[F-1]DefaultCubeにてSpotLightでRealTimeModeを使用しないこと", UnityEngine.LightType.Spot, unusableSpotLightModes),
+                new UseLightModeRule("[F-1]DefaultCubeにてSpotLightで許可されていないModeを使用しないこと", UnityEngine.LightType.Spot, unusableSpotLightModes),
 
                 new LightCountLimitRule(
                     string.Format("[F-1]AreaLightの使用数が{0}個以下であること", AreaLightUsesLimit),

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f714df8a572cc8b42b4f50cea48785e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule/New Scene.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule/New Scene.unity
@@ -1,0 +1,521 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &240991837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 240991839}
+  - component: {fileID: 240991838}
+  m_Layer: 0
+  m_Name: Spotlight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &240991838
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 240991837}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &240991839
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 240991837}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &507701548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 507701550}
+  - component: {fileID: 507701549}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &507701549
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 507701548}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &507701550
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 507701548}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &576958932
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 576958934}
+  - component: {fileID: 576958933}
+  m_Layer: 0
+  m_Name: Point light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &576958933
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 576958932}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 2
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &576958934
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 576958932}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &640354723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 640354727}
+  - component: {fileID: 640354726}
+  - component: {fileID: 640354725}
+  - component: {fileID: 640354724}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &640354724
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640354723}
+  m_Enabled: 1
+--- !u!124 &640354725
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640354723}
+  m_Enabled: 1
+--- !u!20 &640354726
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640354723}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &640354727
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640354723}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &828681234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 828681236}
+  - component: {fileID: 828681235}
+  m_Layer: 0
+  m_Name: Spotlight (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &828681235
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 828681234}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &828681236
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 828681234}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &1736216769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1736216771}
+  - component: {fileID: 1736216770}
+  m_Layer: 0
+  m_Name: Point light (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1736216770
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736216769}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 2
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 1
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1736216771
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1736216769}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule/New Scene.unity.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule/New Scene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6715db7e06dc5524cb31ab839472277c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestUseLightModeRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestUseLightModeRule.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace VitDeck.Validator.Test
+{
+    public class TestUseLightModeRule
+    {
+        [TestCase(LightType.Directional, new[] { LightmapBakeType.Baked })]
+        [TestCase(LightType.Spot, new[] { LightmapBakeType.Mixed })]
+        [TestCase(LightType.Point, new[] { LightmapBakeType.Baked })]
+        [TestCase(LightType.Area, new[] { LightmapBakeType.Baked })]
+        [TestCase(LightType.Directional, new LightmapBakeType[] {})]
+        public void TestValidate(LightType type, LightmapBakeType[] unusableBakeTypes)
+        {
+            var rule = new UseLightModeRule("特定のLightのModeについて検証するルール", type, unusableBakeTypes);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule", true);
+            var result = rule.Validate(target);
+            Assert.That(result.RuleName,Is.EqualTo("特定のLightのModeについて検証するルール"));
+            Assert.That(result.Issues.Count, Is.Zero);
+        }
+
+        [TestCase(LightType.Directional, new[] { LightmapBakeType.Realtime })]
+        [TestCase(LightType.Spot, new[] { LightmapBakeType.Realtime })]
+        [TestCase(LightType.Point, new[] { LightmapBakeType.Realtime })]
+        public void TestValidateError(LightType type, LightmapBakeType[] unusableBakeTypes)
+        {
+            var rule = new UseLightModeRule(string.Format("{0}LightのModeについて検証するルール", type), type, unusableBakeTypes);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/F01_UseLightModeRule", true);
+            var result = rule.Validate(target);
+            Assert.That(result.RuleName, Is.EqualTo(string.Format("{0}LightのModeについて検証するルール", type)));
+            Assert.That(result.Issues.Count, Is.EqualTo(1));
+            var obj = result.Issues[0].target as GameObject;
+            var light = obj.GetComponent<Light>();
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}Lightの{1} Modeは使用できません。", type, light.lightmapBakeType)));
+            Assert.That(result.Issues[0].solution, Is.EqualTo("使用申請をするかModeを変更して下さい。"));
+            Debug.Log(string.Format("{0}LightのModeについて検証するルール", type));
+            Debug.Log(result.Issues[0].message);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestUseLightModeRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/F01_TestUseLightModeRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3aa63f31f937b1e45b6c046736a0ab0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
DefaultCubeにてPointLightとSpotLightのRealtimeLightが使われていないか検証するルールを追加

DefaultCube以外では検証は不要であるため、引数の検出するModeに何も与えないことでルールクラス内部で検証せずに終了させるようにしている。